### PR TITLE
chore(package.json): Remove extraneous dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Both the devmode and production servers provide a way to proxy requests to
 remote HTTP APIs.  This can be useful for working around CORS issues when
 developing your software.
 
-Edit [this file](server/proxy-config.js) to mount such APIs at a given path.
+Edit [this file](webpack.config.js) to mount such APIs at a given path.
 
 ## Improvements
 

--- a/package.json
+++ b/package.json
@@ -24,8 +24,6 @@
   },
   "devDependencies": {
     "autoprefixer": "^6.3.3",
-    "babel": "^6.5.2",
-    "babel-cli": "^6.8.0",
     "babel-core": "^6.4.0",
     "babel-eslint": "^6.0.2",
     "babel-loader": "^6.2.1",
@@ -34,10 +32,7 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.11.0",
     "babel-preset-stage-0": "^6.3.13",
-    "babel-register": "^6.9.0",
-    "body-parser": "^1.15.1",
     "classnames": "^2.2.3",
-    "concurrently": "^2.0.0",
     "cross-env": "^2.0.0",
     "css-loader": "^0.23.0",
     "cssnano": "^3.7.2",
@@ -67,9 +62,6 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-spec-reporter": "0.0.26",
     "karma-webpack": "^1.7.0",
-    "nodemon": "^1.9.2",
-    "passport": "^0.3.2",
-    "passport-local": "^1.0.0",
     "postcss-cssnext": "^2.4.0",
     "postcss-import": "^8.1.2",
     "postcss-loader": "^0.9.1",
@@ -99,13 +91,6 @@
     "webpack-hot-middleware": "^2.12.0",
     "webpack-split-by-path": "0.0.10",
     "whatwg-fetch": "^1.0.0"
-  },
-  "dependencies": {
-    "express": "^4.13.3",
-    "helmet": "^2.0.0",
-    "http-proxy": "^1.12.1",
-    "winston": "^2.1.1",
-    "http-server": "^0.9.0"
   },
   "keywords": [
     "react",


### PR DESCRIPTION
It looks like there were a few extraneous dependencies left over from when the starter was separated from the example project. This PR removes those dependencies. 

Additionally, the README.md was pointing to a nonexistent file in the "Connecting to remote APIs" section.